### PR TITLE
Display waifu status and change opensea api to burned traits

### DIFF
--- a/src/routes/opensea/handler.ts
+++ b/src/routes/opensea/handler.ts
@@ -16,8 +16,13 @@ export const getWaifuByTokenId = async (
     revealedTokenIndex
   );
 
-  const openSeaFormattedAttributes = Object.entries(attributes).map(
+  const ownerAddr = await req.fastify.waifusContract.methods
+    .ownerOf(waifuId)
+    .call({});
+    
+  const openSeaFormattedAttributes: any[] = Object.entries(attributes).map(
     ([trait_type, value]) => {
+      value = ownerAddr == "0x0000000000000000000000000000000000080085" ? "burned" : value;
       return {
         trait_type,
         value,
@@ -25,12 +30,23 @@ export const getWaifuByTokenId = async (
     }
   );
 
+  let status = "freed" 
+  if (ownerAddr == "0x0000000000000000000000000000000000080085") {
+    status = "burned"
+  } else if (ownerAddr.toLowerCase() == "0xb291984262259bcfe6aa02b66a06e9769c5c1ef3") {
+    status = "dungeon"
+  }
+  openSeaFormattedAttributes.push({
+    trait_type: "Status",
+    value: status,
+  })
+
   const ipfsUrl = `${Config.ETH.IPFS_PREFIX}/${revealedTokenIndex}.png`;
-  const detailUrl = `https://waifusion.sexy/app/detail/${revealedTokenIndex}`;
+  const detailUrl = `https://waifusion.io/waifu/${revealedTokenIndex}`;
 
   reply.send({
     name,
-    description: `Waifu #${req.params.waifuId}\n\nYou can claim WET and change your Waifu's name on [waifusion.sexy](https://waifusion.sexy).\n\nWaifusion is a digital Waifu collection. There are 16,384 guaranteed-unique Waifusion NFTs. They’re just like you; a beautiful work of art, but 2-D and therefore, superior, Anon-kun. Each Waifu is wholly unique and yours forever... unless you sell them... Baka.\n\n**Warning**: Waifu names can change at any time. Immediately before purchasing a Waifu, enter the Waifu's token ID into the tokenNameByIndex function on a site like Etherscan to verify that the blockchain indicates that the Waifu you're purchasing has the name you expect.`,
+    description: `Waifu #${req.params.waifuId}\n\nYou can claim WET and change your Waifu's name on [waifusion.io](https://waifusion.io).\n\nWaifusion is a community-run digital Waifu NFT project with deflationary mechanics. There are 16,384 guaranteed-unique Waifusion NFTs. They’re just like you; a beautiful work of art, but 2-D and therefore, superior, Anon-kun. Each Waifu is wholly unique and yours forever... unless you sell them... Baka.\n\n**Warning**: Waifu names can change at any time. Immediately before purchasing a Waifu, enter the Waifu's token ID into the tokenNameByIndex function on a site like Etherscan to verify that the blockchain indicates that the Waifu you're purchasing has the name you expect.`,
     image: ipfsUrl,
     external_url: detailUrl,
     attributes: openSeaFormattedAttributes,

--- a/src/routes/opensea/handler.ts
+++ b/src/routes/opensea/handler.ts
@@ -22,7 +22,7 @@ export const getWaifuByTokenId = async (
     
   const openSeaFormattedAttributes: any[] = Object.entries(attributes).map(
     ([trait_type, value]) => {
-      value = ownerAddr == "0x0000000000000000000000000000000000080085" ? "burned" : value;
+      value = ownerAddr === "0x0000000000000000000000000000000000080085" ? "burned" : value;
       return {
         trait_type,
         value,
@@ -31,9 +31,9 @@ export const getWaifuByTokenId = async (
   );
 
   let status = "freed" 
-  if (ownerAddr == "0x0000000000000000000000000000000000080085") {
+  if (ownerAddr === "0x0000000000000000000000000000000000080085") {
     status = "burned"
-  } else if (ownerAddr.toLowerCase() == "0xb291984262259bcfe6aa02b66a06e9769c5c1ef3") {
+  } else if (ownerAddr.toLowerCase() === "0xb291984262259bcfe6aa02b66a06e9769c5c1ef3") {
     status = "dungeon"
   }
   openSeaFormattedAttributes.push({

--- a/src/util/dataTransformer.ts
+++ b/src/util/dataTransformer.ts
@@ -21,14 +21,24 @@ export const createWaifuObjectFromScrapeDataObject = async (
     ? await waifuContract.methods.tokenNameByIndex(waifuId).call({})
     : "";
 
-  const owner = fetchExternal && bsc ? await getOwnerObjectForTokenId(waifuId) : null;
+  const owner = fetchExternal && !bsc ? await getOwnerObjectForTokenId(waifuId) : null;
 
   const { attributes } = prefilledObject || (bsc ? 
     app.getBSCWaifuByRevealedIndex(revealedTokenIndex) : app.getWaifuByRevealedIndex(revealedTokenIndex)
   );
 
   const formattedAttributes: any[] = bsc ? attributes.filter((atr: IWaifuAttribute) => atr.value) : formatAttributesFromScrape(attributes);
-
+  
+  let status = "freed" 
+  if (owner.address == "0x0000000000000000000000000000000000080085") {
+    status = "burned"
+  } else if (owner.address.toLowerCase() == "0xb291984262259bcfe6aa02b66a06e9769c5c1ef3") {
+    status = "dungeon"
+  }
+  formattedAttributes.push({
+    trait_type: "Status",
+    value: status,
+  })
   const imageUrl = `${Config[bsc ? "BSC" : "ETH"].HAREM_CDN_PREFIX}/${waifuId}.png`;
   const detailUrl = !bsc ? `https://waifusion.io/waifu/${waifuId}` : `https://waifusionbsc.sexy/app/detail/${waifuId}`;
 

--- a/src/util/dataTransformer.ts
+++ b/src/util/dataTransformer.ts
@@ -30,9 +30,9 @@ export const createWaifuObjectFromScrapeDataObject = async (
   const formattedAttributes: any[] = bsc ? attributes.filter((atr: IWaifuAttribute) => atr.value) : formatAttributesFromScrape(attributes);
   
   let status = "freed" 
-  if (owner.address == "0x0000000000000000000000000000000000080085") {
+  if (owner.address === "0x0000000000000000000000000000000000080085") {
     status = "burned"
-  } else if (owner.address.toLowerCase() == "0xb291984262259bcfe6aa02b66a06e9769c5c1ef3") {
+  } else if (owner.address.toLowerCase() === "0xb291984262259bcfe6aa02b66a06e9769c5c1ef3") {
     status = "dungeon"
   }
   formattedAttributes.push({


### PR DESCRIPTION
This changes the API to add a new trait `Status` which can be `freed, dungeon, burned` based on the owner address of the waifu.

Also for OpenSea, this changes all of a burned waifus traits to "burned", so they no longer appear when someone is looking for a specific trait on OpenSea. 

Still debating on whether the latter is needed. People can always manually filter out burned via status, but changing the traits to burned means rarity will be updated which will be nice.